### PR TITLE
Qt: consolidate handling of popups that use CoreController

### DIFF
--- a/src/platform/qt/BattleChipView.cpp
+++ b/src/platform/qt/BattleChipView.cpp
@@ -8,6 +8,7 @@
 #include "BattleChipUpdater.h"
 #include "ConfigController.h"
 #include "CoreController.h"
+#include "CorePointerSource.h"
 #include "GBAApp.h"
 #include "ShortcutController.h"
 #include "Window.h"
@@ -22,9 +23,9 @@
 
 using namespace QGBA;
 
-BattleChipView::BattleChipView(std::shared_ptr<CoreController> controller, Window* window, QWidget* parent)
+BattleChipView::BattleChipView(CorePointerSource* controller, Window* window, QWidget* parent)
 	: QDialog(parent, Qt::WindowTitleHint | Qt::WindowSystemMenuHint | Qt::WindowCloseButtonHint)
-	, m_controller(std::move(controller))
+	, CoreConsumer(controller)
 	, m_window(window)
 {
 	m_ui.setupUi(this);

--- a/src/platform/qt/BattleChipView.h
+++ b/src/platform/qt/BattleChipView.h
@@ -13,6 +13,7 @@
 
 #include <mgba/core/interface.h>
 
+#include "CorePointer.h"
 #include "ui_BattleChipView.h"
 
 namespace QGBA {
@@ -20,11 +21,11 @@ namespace QGBA {
 class CoreController;
 class Window;
 
-class BattleChipView : public QDialog {
+class BattleChipView : public QDialog, public CoreConsumer {
 Q_OBJECT
 
 public:
-	BattleChipView(std::shared_ptr<CoreController> controller, Window* window, QWidget* parent = nullptr);
+	BattleChipView(CorePointerSource* controller, Window* window, QWidget* parent = nullptr);
 	~BattleChipView();
 
 public slots:
@@ -51,7 +52,6 @@ private:
 	Ui::BattleChipView m_ui;
 
 	BattleChipModel m_model;
-	std::shared_ptr<CoreController> m_controller;
 
 	int m_frameCounter = -1;
 	bool m_next = false;

--- a/src/platform/qt/CMakeLists.txt
+++ b/src/platform/qt/CMakeLists.txt
@@ -155,6 +155,7 @@ set(SOURCE_FILES
 	OverrideView.cpp
 	PaletteView.cpp
 	PlacementControl.cpp
+	PopupManager.cpp
 	RegisterView.cpp
 	ReportView.cpp
 	ROMInfo.cpp

--- a/src/platform/qt/CheatsView.cpp
+++ b/src/platform/qt/CheatsView.cpp
@@ -5,8 +5,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 #include "CheatsView.h"
 
-#include "GBAApp.h"
 #include "CoreController.h"
+#include "CorePointerSource.h"
+#include "GBAApp.h"
 #include "LogController.h"
 
 #include <QBoxLayout>
@@ -25,10 +26,10 @@
 
 using namespace QGBA;
 
-CheatsView::CheatsView(std::shared_ptr<CoreController> controller, QWidget* parent)
+CheatsView::CheatsView(CorePointerSource* controller, QWidget* parent)
 	: QWidget(parent)
-	, m_controller(controller)
-	, m_model(controller->cheatDevice())
+	, CoreConsumer(controller)
+	, m_model(m_controller->cheatDevice())
 {
 	m_ui.setupUi(this);
 
@@ -41,9 +42,9 @@ CheatsView::CheatsView(std::shared_ptr<CoreController> controller, QWidget* pare
 	connect(m_ui.addSet, &QAbstractButton::clicked, this, &CheatsView::addSet);
 	connect(m_ui.remove, &QAbstractButton::clicked, this, &CheatsView::removeSet);
 	connect(m_ui.add, &QAbstractButton::clicked, this, &CheatsView::enterCheat);
-	connect(controller.get(), &CoreController::stateLoaded, &m_model, &CheatsModel::invalidated);
+	connect(m_controller.get(), &CoreController::stateLoaded, &m_model, &CheatsModel::invalidated);
 
-	switch (controller->platform()) {
+	switch (m_controller->platform()) {
 #ifdef M_CORE_GBA
 	case mPLATFORM_GBA:
 		registerCodeType(tr("Autodetect (recommended)"), GBA_CHEAT_AUTODETECT);

--- a/src/platform/qt/CheatsView.h
+++ b/src/platform/qt/CheatsView.h
@@ -11,7 +11,7 @@
 #include <memory>
 
 #include "CheatsModel.h"
-
+#include "CorePointer.h"
 #include "ui_CheatsView.h"
 
 struct mCheatDevice;
@@ -20,11 +20,11 @@ namespace QGBA {
 
 class CoreController;
 
-class CheatsView : public QWidget {
+class CheatsView : public QWidget, public CoreConsumer {
 Q_OBJECT
 
 public:
-	CheatsView(std::shared_ptr<CoreController> controller, QWidget* parent = nullptr);
+	CheatsView(CorePointerSource* controller, QWidget* parent = nullptr);
 
 	virtual bool eventFilter(QObject*, QEvent*) override;
 
@@ -39,7 +39,6 @@ private:
 	void registerCodeType(const QString& label, int type);
 
 	Ui::CheatsView m_ui;
-	std::shared_ptr<CoreController> m_controller;
 	CheatsModel m_model;
 	QButtonGroup* m_typeGroup = nullptr;
 

--- a/src/platform/qt/IOViewer.cpp
+++ b/src/platform/qt/IOViewer.cpp
@@ -6,6 +6,7 @@
 #include "IOViewer.h"
 
 #include "CoreController.h"
+#include "CorePointerSource.h"
 #include "GBAApp.h"
 
 #include <QComboBox>
@@ -1560,14 +1561,14 @@ const QList<IOViewer::RegisterDescription>& IOViewer::registerDescriptions(mPlat
 	return s_registers[platform];
 }
 
-IOViewer::IOViewer(std::shared_ptr<CoreController> controller, QWidget* parent)
+IOViewer::IOViewer(CorePointerSource* controller, QWidget* parent)
 	: QDialog(parent, Qt::WindowTitleHint | Qt::WindowSystemMenuHint | Qt::WindowCloseButtonHint)
-	, m_controller(controller)
+	, CoreConsumer(controller)
 {
 	m_ui.setupUi(this);
 	const char* const* regs;
 	unsigned maxRegs;
-	switch (controller->platform()) {
+	switch (m_controller->platform()) {
 #ifdef M_CORE_GB
 	case mPLATFORM_GB:
 		regs = GBIORegisterNames;

--- a/src/platform/qt/IOViewer.h
+++ b/src/platform/qt/IOViewer.h
@@ -12,13 +12,14 @@
 
 #include <memory>
 
+#include "CorePointer.h"
 #include "ui_IOViewer.h"
 
 namespace QGBA {
 
 class CoreController;
 
-class IOViewer : public QDialog {
+class IOViewer : public QDialog, public CoreConsumer {
 Q_OBJECT
 
 public:
@@ -42,7 +43,7 @@ public:
 	};
 	typedef QList<RegisterItem> RegisterDescription;
 
-	IOViewer(std::shared_ptr<CoreController> controller, QWidget* parent = nullptr);
+	IOViewer(CorePointerSource* controller, QWidget* parent = nullptr);
 
 	static const QList<RegisterDescription>& registerDescriptions(mPlatform);
 
@@ -69,8 +70,6 @@ private:
 	uint16_t m_value;
 
 	QCheckBox* m_b[16];
-
-	std::shared_ptr<CoreController> m_controller;
 };
 
 }

--- a/src/platform/qt/MemoryView.cpp
+++ b/src/platform/qt/MemoryView.cpp
@@ -11,6 +11,7 @@
 #include "CorePointerSource.h"
 #include "MemoryAccessLogView.h"
 #include "MemoryDump.h"
+#include "PopupManager.h"
 
 #include <mgba/core/core.h>
 
@@ -200,13 +201,10 @@ MemoryView::MemoryView(CorePointerSource* controller, QWidget* parent)
 	connect(m_ui.hexfield, &MemoryModel::selectionChanged, &m_malModel, &MemoryAccessLogModel::updateSelection);
 	connect(m_ui.segments, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
 	        &m_malModel, &MemoryAccessLogModel::setSegment);
-	connect(m_ui.accessLoggerButton, &QAbstractButton::clicked, this, [this]() {
+	connect(m_ui.accessLoggerButton, &QAbstractButton::clicked, PopupManager<MemoryAccessLogView>().constructWith([this] {
 		std::weak_ptr<MemoryAccessLogController> controller = m_controller->memoryAccessLogController();
-		MemoryAccessLogView* view = new MemoryAccessLogView(controller);
-		connect(m_controller.get(), &CoreController::stopping, view, &QWidget::close);
-		view->setAttribute(Qt::WA_DeleteOnClose);
-		view->show();
-	});
+		return new MemoryAccessLogView(controller);
+	}));
 	m_ui.accessLog->setModel(&m_malModel);
 #else
 	m_ui.accessLog->hide();

--- a/src/platform/qt/PaletteView.cpp
+++ b/src/platform/qt/PaletteView.cpp
@@ -24,18 +24,18 @@
 
 using namespace QGBA;
 
-PaletteView::PaletteView(std::shared_ptr<CoreController> controller, QWidget* parent)
+PaletteView::PaletteView(CorePointerSource* controller, QWidget* parent)
 	: QWidget(parent)
-	, m_controller(controller)
+	, CoreConsumer(controller)
 {
 	m_ui.setupUi(this);
 
-	connect(controller.get(), &CoreController::frameAvailable, this, &PaletteView::updatePalette);
+	connect(m_controller.get(), &CoreController::frameAvailable, this, &PaletteView::updatePalette);
 	m_ui.bgGrid->setDimensions(QSize(16, 16));
 	m_ui.objGrid->setDimensions(QSize(16, 16));
 	int count = 256;
 #ifdef M_CORE_GB
-	if (controller->platform() == mPLATFORM_GB) {
+	if (m_controller->platform() == mPLATFORM_GB) {
 		m_ui.bgGrid->setDimensions(QSize(4, 8));
 		m_ui.objGrid->setDimensions(QSize(4, 8));
 		m_ui.bgGrid->setSize(24);

--- a/src/platform/qt/PaletteView.h
+++ b/src/platform/qt/PaletteView.h
@@ -9,6 +9,7 @@
 
 #include <memory>
 
+#include "CorePointer.h"
 #include "Swatch.h"
 
 #include "ui_PaletteView.h"
@@ -18,11 +19,11 @@ namespace QGBA {
 class CoreController;
 class Swatch;
 
-class PaletteView : public QWidget {
+class PaletteView : public QWidget, public CoreConsumer {
 Q_OBJECT
 
 public:
-	PaletteView(std::shared_ptr<CoreController> controller, QWidget* parent = nullptr);
+	PaletteView(CorePointerSource* controller, QWidget* parent = nullptr);
 
 public slots:
 	void updatePalette();
@@ -34,8 +35,6 @@ private:
 	void exportPalette(int start, int length);
 
 	Ui::PaletteView m_ui;
-
-	std::shared_ptr<CoreController> m_controller;
 };
 
 }

--- a/src/platform/qt/PlacementControl.cpp
+++ b/src/platform/qt/PlacementControl.cpp
@@ -6,6 +6,7 @@
 #include "PlacementControl.h"
 
 #include "CoreController.h"
+#include "CorePointerSource.h"
 
 #include <QGridLayout>
 
@@ -13,9 +14,9 @@
 
 using namespace QGBA;
 
-PlacementControl::PlacementControl(std::shared_ptr<CoreController> controller, QWidget* parent)
+PlacementControl::PlacementControl(CorePointerSource* controller, QWidget* parent)
 	: QDialog(parent, Qt::WindowTitleHint | Qt::WindowSystemMenuHint | Qt::WindowCloseButtonHint)
-	, m_controller(std::move(controller))
+	, CoreConsumer(controller)
 {
 	m_ui.setupUi(this);
 

--- a/src/platform/qt/PlacementControl.h
+++ b/src/platform/qt/PlacementControl.h
@@ -10,22 +10,22 @@
 
 #include <memory>
 
+#include "CorePointer.h"
 #include "ui_PlacementControl.h"
 
 namespace QGBA {
 
 class CoreController;
 
-class PlacementControl : public QDialog {
+class PlacementControl : public QDialog, public CoreConsumer {
 Q_OBJECT
 
 public:
-	PlacementControl(std::shared_ptr<CoreController>, QWidget* parent = nullptr);
+	PlacementControl(CorePointerSource* controller, QWidget* parent = nullptr);
 
 private:
 	void adjustLayer(int layer, int32_t x, int32_t y);
 
-	std::shared_ptr<CoreController> m_controller;
 	QList<QPair<QSpinBox*, QSpinBox*>> m_layers;
 
 	Ui::PlacementControl m_ui;

--- a/src/platform/qt/PopupManager.cpp
+++ b/src/platform/qt/PopupManager.cpp
@@ -1,0 +1,58 @@
+/* Copyright (c) 2013-2025 Jeffrey Pfau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#include "PopupManager.h"
+
+#include <QDialog>
+
+#include "CoreController.h"
+
+using namespace QGBA;
+
+PopupManagerBase::PopupManagerBase(PopupManagerBase::Private* d)
+	: m_d(d)
+{
+	// initializers only
+}
+
+void PopupManagerBase::show() {
+	QWidget* w = construct();
+	if (!w) {
+		return;
+	}
+	w->show();
+	w->activateWindow();
+	w->raise();
+}
+
+QWidget* PopupManagerBase::construct() {
+	QWidget* w = d()->window();
+	if (w) {
+		return w;
+	}
+	constructImpl();
+	w = d()->window();
+	if (w && d()->keepAlive) {
+		w->setAttribute(Qt::WA_DeleteOnClose);
+	}
+	if (d()->m_controller) {
+		d()->onCoreAttached(d()->m_controller.getShared());
+	}
+	return w;
+}
+
+void PopupManagerBase::Private::onCoreDetached(std::shared_ptr<CoreController>) {
+	if (stopConnection) {
+		QObject::disconnect(stopConnection);
+		stopConnection = QMetaObject::Connection();
+	}
+}
+
+void PopupManagerBase::Private::onCoreAttached(std::shared_ptr<CoreController> controller) {
+	QWidget* widget = window();
+	if (widget) {
+		stopConnection = QObject::connect(controller.get(), &CoreController::stopping, widget, &QWidget::close);
+	}
+}

--- a/src/platform/qt/PopupManager.h
+++ b/src/platform/qt/PopupManager.h
@@ -1,0 +1,151 @@
+/* Copyright (c) 2013-2025 Jeffrey Pfau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#pragma once
+
+#include <QExplicitlySharedDataPointer>
+#include <QPointer>
+#include <QSharedData>
+
+#include <functional>
+#include <memory>
+#include <type_traits>
+
+#include "CorePointer.h"
+
+namespace QGBA {
+
+class CoreController;
+
+class PopupManagerBase {
+public:
+	PopupManagerBase(const PopupManagerBase&) = default;
+	virtual ~PopupManagerBase() = default;
+
+	QWidget* construct();
+	void show();
+	inline void operator()() { show(); }
+
+protected:
+	class Private : public QSharedData, public CoreConsumer {
+	public:
+		Private(PopupManagerBase* pub) : pub(pub) {}
+		Private(const Private& other) = default;
+
+		using CoreConsumer::m_controller;
+
+		PopupManagerBase* pub;
+		QMetaObject::Connection stopConnection;
+		bool keepAlive = false;
+
+		virtual QWidget* window() const = 0;
+
+		void onCoreDetached(std::shared_ptr<CoreController>) override;
+		void onCoreAttached(std::shared_ptr<CoreController>) override;
+	};
+
+	PopupManagerBase(Private* d);
+
+	virtual void constructImpl() = 0;
+
+	virtual Private* d() const { return m_d.data(); }
+	virtual Private* d() { return m_d.data(); }
+
+private:
+	QExplicitlySharedDataPointer<Private> m_d;
+};
+
+template <class WINDOW>
+class PopupManager : public PopupManagerBase {
+	static_assert(std::is_convertible<WINDOW*, QWidget*>::value, "class must derive from QWidget");
+
+	template <typename T>
+	struct is_window_function {
+		static constexpr bool value = std::is_convertible<T, std::function<WINDOW*()>>::value;
+	};
+
+protected:
+	class Private;
+	Private* d() const override { return static_cast<Private*>(PopupManagerBase::d()); }
+	Private* d() override { return static_cast<Private*>(PopupManagerBase::d()); }
+
+public:
+	PopupManager() : PopupManagerBase(new Private(this)) {}
+	PopupManager(CorePointerSource& source) : PopupManagerBase(new Private(this)) {
+		d()->m_controller.setSource(&source);
+	}
+	PopupManager(const PopupManager&) = default;
+
+	bool isNull() const { return d()->ptr.isNull(); }
+	WINDOW* operator->() const { return d()->ptr; }
+	WINDOW& operator*() const { return &d()->ptr; }
+	operator WINDOW*() const { return d()->ptr; }
+
+	PopupManager& setKeepAlive(bool keepAlive) { d()->keepAlive = keepAlive; return *this; }
+
+	// Construct by invoking a lambda that returns WINDOW*
+	template <typename FUNC, typename std::enable_if<is_window_function<FUNC>::value, bool>::type = true>
+	PopupManager& constructWith(const FUNC& ctor) {
+		d()->construct = ctor;
+		return *this;
+	}
+
+	// Construct by calling the WINDOW constructor with the specified args
+	template <typename... Args>
+	PopupManager& constructWith(Args... args) {
+		return constructWith([=]() -> WINDOW* { return new WINDOW(args...); });
+	}
+
+protected:
+	virtual void constructImpl() override {
+		Private* d = this->d();
+		if (!d->construct) {
+			qWarning("No valid constructor specified for popup");
+			return;
+		}
+		WINDOW* w = d->construct();
+		if (!w) {
+			qWarning("Constructor did not return a window");
+			return;
+		}
+		d->ptr = w;
+	}
+
+	class Private : public PopupManagerBase::Private {
+		template <class T = WINDOW>
+		struct Ctors {
+			static constexpr bool useController = std::is_constructible<T, CorePointerSource*>::value;
+			static constexpr bool useDefault = !useController && std::is_default_constructible<T>::value;
+			static constexpr bool noDefault = !useController && !useDefault;
+		};
+
+	public:
+		template<class T = WINDOW>
+		Private(PopupManagerBase* pub, typename std::enable_if<Ctors<T>::useDefault>::type* = 0)
+		: PopupManagerBase::Private(pub), construct([]{ return new WINDOW(); }) {}
+
+		template<class T = WINDOW>
+		Private(PopupManagerBase* pub, typename std::enable_if<Ctors<T>::useController>::type* = 0)
+		: PopupManagerBase::Private(pub), construct([this]{ return new WINDOW(m_controller.source()); }) {}
+
+		template<class T = WINDOW>
+		Private(PopupManagerBase* pub, typename std::enable_if<Ctors<T>::noDefault>::type* = 0)
+		: PopupManagerBase::Private(pub) {}
+
+		~Private() {
+			if (ptr && !keepAlive) {
+				ptr->close();
+				ptr->deleteLater();
+			}
+		}
+
+		virtual QWidget* window() const override { return ptr.data(); }
+
+		QPointer<WINDOW> ptr;
+		std::function<WINDOW*()> construct;
+	};
+};
+
+}

--- a/src/platform/qt/ROMInfo.cpp
+++ b/src/platform/qt/ROMInfo.cpp
@@ -7,6 +7,7 @@
 
 #include "GBAApp.h"
 #include "CoreController.h"
+#include "CorePointerSource.h"
 
 #include <mgba/core/core.h>
 #ifdef USE_SQLITE3
@@ -24,7 +25,7 @@ template<size_t N> bool isZeroed(const uint8_t* mem) {
 	return true;
 }
 
-ROMInfo::ROMInfo(std::shared_ptr<CoreController> controller, QWidget* parent)
+ROMInfo::ROMInfo(CorePointerSource* controller, QWidget* parent)
 	: QDialog(parent, Qt::WindowTitleHint | Qt::WindowSystemMenuHint | Qt::WindowCloseButtonHint)
 {
 	m_ui.setupUi(this);
@@ -36,8 +37,8 @@ ROMInfo::ROMInfo(std::shared_ptr<CoreController> controller, QWidget* parent)
 	uint8_t md5[16]{};
 	uint8_t sha1[20]{};
 
-	CoreController::Interrupter interrupter(controller);
-	mCore* core = controller->thread()->core;
+	CoreController::Interrupter interrupter(controller->get());
+	mCore* core = controller->get()->thread()->core;
 	mGameInfo info;
 	core->getGameInfo(core, &info);
 	m_ui.title->setText(QLatin1String(info.title));
@@ -94,7 +95,7 @@ ROMInfo::ROMInfo(std::shared_ptr<CoreController> controller, QWidget* parent)
 	m_ui.name->hide();
 #endif
 
-	QString savePath = controller->savePath();
+	QString savePath = controller->get()->savePath();
 	if (!savePath.isEmpty()) {
 		m_ui.savefile->setText(savePath);
 	} else {

--- a/src/platform/qt/ROMInfo.h
+++ b/src/platform/qt/ROMInfo.h
@@ -14,12 +14,13 @@
 namespace QGBA {
 
 class CoreController;
+class CorePointerSource;
 
 class ROMInfo : public QDialog {
 Q_OBJECT
 
 public:
-	ROMInfo(std::shared_ptr<CoreController> controller, QWidget* parent = nullptr);
+	ROMInfo(CorePointerSource* controller, QWidget* parent = nullptr);
 
 private:
 	Ui::ROMInfo m_ui;

--- a/src/platform/qt/Window.cpp
+++ b/src/platform/qt/Window.cpp
@@ -32,26 +32,23 @@
 #include "DebuggerConsole.h"
 #include "DebuggerConsoleController.h"
 #include "Display.h"
-#include "DolphinConnector.h"
 #include "CoreController.h"
 #include "ForwarderView.h"
-#include "FrameView.h"
 #include "GBAApp.h"
 #include "GDBController.h"
 #include "GDBWindow.h"
-#include "GIFView.h"
 #ifdef BUILD_SDL
 #include "input/SDLInputDriver.h"
 #endif
 #include "IOViewer.h"
 #include "LoadSaveState.h"
-#include "LogView.h"
 #include "MapView.h"
+#ifdef ENABLE_DEBUGGERS
 #include "MemoryAccessLogView.h"
+#endif
 #include "MemorySearch.h"
 #include "MemoryView.h"
 #include "MultiplayerController.h"
-#include "OverrideView.h"
 #include "ObjView.h"
 #include "PaletteView.h"
 #include "PlacementControl.h"
@@ -62,12 +59,10 @@
 #ifdef ENABLE_SCRIPTING
 #include "scripting/ScriptingView.h"
 #endif
-#include "SensorView.h"
 #include "ShaderSelector.h"
 #include "ShortcutController.h"
 #include "TileView.h"
 #include "VideoProxy.h"
-#include "VideoView.h"
 
 #ifdef USE_DISCORD_RPC
 #include "DiscordCoordinator.h"
@@ -94,7 +89,6 @@ using namespace QGBA;
 Window::Window(CoreManager* manager, ConfigController* config, int playerId, QWidget* parent)
 	: QMainWindow(parent)
 	, m_manager(manager)
-	, m_logView(new LogView(&m_log, this))
 	, m_screenWidget(new WindowBackground())
 	, m_config(config)
 	, m_inputController(this)
@@ -165,7 +159,6 @@ Window::Window(CoreManager* manager, ConfigController* config, int playerId, QWi
 	}
 	setLogo();
 
-	connect(this, &Window::shutdown, m_logView, &QWidget::hide);
 	connect(&m_fpsTimer, &QTimer::timeout, this, &Window::showFPS);
 	connect(&m_focusCheck, &QTimer::timeout, this, &Window::focusCheck);
 	connect(&m_inputController, &InputController::profileLoaded, m_shortcutController, &ShortcutController::loadProfile);
@@ -194,11 +187,10 @@ Window::Window(CoreManager* manager, ConfigController* config, int playerId, QWi
 	m_shortcutController->setActionMapper(&m_actions);
 	setupMenu(menuBar());
 	setupOptions();
+	setupPopups();
 }
 
 Window::~Window() {
-	delete m_logView;
-
 #ifdef USE_SQLITE3
 	delete m_libraryView;
 #endif
@@ -570,70 +562,6 @@ void Window::startVideoLog() {
 	if (!filename.isEmpty()) {
 		m_controller->startVideoLog(filename);
 	}
-}
-
-template <typename T, typename... A>
-std::function<void()> Window::openTView(A... arg) {
-	return [=]() {
-		T* view = new T(arg...);
-		openView(view);
-	};
-}
-
-namespace {
-class RefAdaptor
-{
-public:
-	RefAdaptor(CorePointerSource& source) : source(&source) {}
-
-	inline operator CorePointerSource&() { return *source; }
-	inline operator CorePointerSource*() { return source; }
-	inline operator std::shared_ptr<CoreController>() { return *source; }
-
-	CorePointerSource* source;
-};
-}
-
-template <typename T, typename... A>
-std::function<void()> Window::openControllerTView(A... arg) {
-	return [=]() {
-		T* view = new T(RefAdaptor(m_controller), arg...);
-		connect(m_controller.get(), &CoreController::stopping, view, &QWidget::close);
-		openView(view);
-	};
-}
-
-template <typename T, typename... A>
-std::function<void()> Window::openNamedTView(QPointer<T>* name, bool keepalive, A... arg) {
-	return [=]() {
-		if (!*name) {
-			*name = new T(arg...);
-			connect(this, &Window::shutdown, name->data(), &QWidget::close);
-			if (!keepalive) {
-				(*name)->setAttribute(Qt::WA_DeleteOnClose);
-			}
-		}
-		(*name)->show();
-		(*name)->activateWindow();
-		(*name)->raise();
-	};
-}
-
-template <typename T, typename... A>
-std::function<void()> Window::openNamedControllerTView(QPointer<T>* name, bool keepalive, A... arg) {
-	return [=]() {
-		if (!*name) {
-			*name = new T(&m_controller, arg...);
-			connect(m_controller.get(), &CoreController::stopping, name->data(), &QWidget::close);
-			connect(this, &Window::shutdown, name->data(), &QWidget::close);
-			if (!keepalive) {
-				(*name)->setAttribute(Qt::WA_DeleteOnClose);
-			}
-		}
-		(*name)->show();
-		(*name)->activateWindow();
-		(*name)->raise();
-	};
 }
 
 #ifdef ENABLE_GDB_STUB
@@ -1330,7 +1258,7 @@ void Window::setupMenu(QMenuBar* menubar) {
 
 	m_actions.addSeparator("saves");
 
-	m_actions.addAction(tr("Convert save game..."), "convertSave", openTView<SaveConverter>(), "saves");
+	m_actions.addAction(tr("Convert save game..."), "convertSave", PopupManager<SaveConverter>(), "saves");
 
 #ifdef M_CORE_GBA
 	auto importShark = addGameAction(tr("Import GameShark Save..."), "importShark", this, &Window::importSharkport, "saves");
@@ -1368,7 +1296,7 @@ void Window::setupMenu(QMenuBar* menubar) {
 	m_platformActions.insert(mPLATFORM_GBA, scanCard);
 #endif
 
-	addGameAction(tr("ROM &info..."), "romInfo", openControllerTView<ROMInfo>(), "file");
+	addGameAction(tr("ROM &info..."), "romInfo", PopupManager<ROMInfo>(m_controller), "file");
 
 	m_actions.addMenu(tr("Recent"), "mru", "file");
 	m_actions.addSeparator("file");
@@ -1434,19 +1362,19 @@ void Window::setupMenu(QMenuBar* menubar) {
 	m_multiWindow = m_actions.addAction(tr("New multiplayer window"), "multiWindow", GBAApp::app(), &GBAApp::newWindow, "file");
 
 #ifdef M_CORE_GBA
-	auto dolphin = m_actions.addAction(tr("Connect to Dolphin..."), "connectDolphin", openNamedTView<DolphinConnector>(&m_dolphinView, true, this), "file");
+	auto dolphin = m_actions.addAction(tr("Connect to Dolphin..."), "connectDolphin", m_dolphinView, "file");
 	m_platformActions.insert(mPLATFORM_GBA, dolphin);
 #endif
 
 	m_actions.addSeparator("file");
 
-	m_actions.addAction(tr("Report bug..."), "bugReport", openTView<ReportView>(), "file");
+	m_actions.addAction(tr("Report bug..."), "bugReport", PopupManager<ReportView>(), "file");
 
 #ifndef Q_OS_MAC
 	m_actions.addSeparator("file");
 #endif
 
-	m_actions.addAction(tr("About..."), "about", openTView<AboutScreen>(), "file")->setRole(Action::Role::ABOUT);
+	m_actions.addAction(tr("About..."), "about", PopupManager<AboutScreen>(), "file")->setRole(Action::Role::ABOUT);
 	m_actions.addAction(tr("E&xit"), "quit", &QApplication::quit, "file", QKeySequence::Quit)->setRole(Action::Role::QUIT);
 
 	m_actions.addMenu(tr("&Emulation"), "emu");
@@ -1552,16 +1480,15 @@ void Window::setupMenu(QMenuBar* menubar) {
 #ifdef M_CORE_GB
 	m_actions.addAction(tr("Load camera image..."), "loadCamImage", this, &Window::loadCamImage, "emu");
 
-	auto gbPrint = addGameAction(tr("Game Boy Printer..."), "gbPrint", [this]() {
-		PrinterView* view = new PrinterView(m_controller);
-		openView(view);
+	auto gbPrint = addGameAction(tr("Game Boy Printer..."), "gbPrint", PopupManager<PrinterView>().constructWith([this]() {
 		m_controller->attachPrinter();
-	}, "emu");
+		return new PrinterView(m_controller);
+	}), "emu");
 	m_platformActions.insert(mPLATFORM_GB, gbPrint);
 #endif
 
 #ifdef M_CORE_GBA
-	auto bcGate = addGameAction(tr("BattleChip Gate..."), "bcGate", openControllerTView<BattleChipView>(this), "emu");
+	auto bcGate = addGameAction(tr("BattleChip Gate..."), "bcGate", PopupManager<BattleChipView>().constructWith(&m_controller, this), "emu");
 	m_platformActions.insert(mPLATFORM_GBA, bcGate);
 #endif
 
@@ -1715,45 +1642,27 @@ void Window::setupMenu(QMenuBar* menubar) {
 #endif
 
 #ifdef USE_FFMPEG
-	addGameAction(tr("Record A/V..."), "recordOutput", openNamedControllerTView<VideoView>(&m_videoView, true), "av");
-	addGameAction(tr("Record GIF/WebP/APNG..."), "recordGIF", openNamedControllerTView<GIFView>(&m_gifView, true), "av");
+	addGameAction(tr("Record A/V..."), "recordOutput", m_videoView, "av");
+	addGameAction(tr("Record GIF/WebP/APNG..."), "recordGIF", m_gifView, "av");
 #endif
 
 	m_actions.addSeparator("av");
 	m_actions.addMenu(tr("Video layers"), "videoLayers", "av");
 	m_actions.addMenu(tr("Audio channels"), "audioChannels", "av");
 
-	addGameAction(tr("Adjust layer placement..."), "placementControl", openControllerTView<PlacementControl>(), "av");
+	addGameAction(tr("Adjust layer placement..."), "placementControl", PopupManager<PlacementControl>(m_controller), "av");
 
 	m_actions.addMenu(tr("&Tools"), "tools");
-	m_actions.addAction(tr("View &logs..."), "viewLogs", static_cast<QWidget*>(m_logView), &QWidget::show, "tools");
+	m_actions.addAction(tr("View &logs..."), "viewLogs", m_logView, "tools");
+	m_actions.addAction(tr("Game &overrides..."), "overrideWindow", m_overrideView, "tools");
+	m_actions.addAction(tr("Game Pak sensors..."), "sensorWindow", m_sensorView, "tools");
 
-	m_actions.addAction(tr("Game &overrides..."), "overrideWindow", [this]() {
-		if (!m_overrideView) {
-			m_overrideView = new OverrideView(&m_controller, m_config);
-			connect(this, &Window::shutdown, m_overrideView.data(), &QWidget::close);
-		}
-		m_overrideView->show();
-		m_overrideView->activateWindow();
-		m_overrideView->raise();
-	}, "tools");
-
-	m_actions.addAction(tr("Game Pak sensors..."), "sensorWindow", [this]() {
-		if (!m_sensorView) {
-			m_sensorView = new SensorView(&m_controller, &m_inputController);
-			connect(this, &Window::shutdown, m_sensorView.data(), &QWidget::close);
-		}
-		m_sensorView->show();
-		m_sensorView->activateWindow();
-		m_sensorView->raise();
-	}, "tools");
-
-	addGameAction(tr("&Cheats..."), "cheatsWindow", openControllerTView<CheatsView>(), "tools");
+	addGameAction(tr("&Cheats..."), "cheatsWindow", PopupManager<CheatsView>(m_controller), "tools");
 #ifdef ENABLE_SCRIPTING
 	m_actions.addAction(tr("Scripting..."), "scripting", this, &Window::scriptingOpen, "tools");
 #endif
 
-	m_actions.addAction(tr("Create forwarder..."), "createForwarder", openTView<ForwarderView>(), "tools");
+	m_actions.addAction(tr("Create forwarder..."), "createForwarder", PopupManager<ForwarderView>(), "tools");
 
 	m_actions.addSeparator("tools");
 	m_actions.addAction(tr("Settings..."), "settings", this, &Window::openSettingsWindow, "tools")->setRole(Action::Role::SETTINGS);
@@ -1772,22 +1681,20 @@ void Window::setupMenu(QMenuBar* menubar) {
 #endif
 
 	m_actions.addMenu(tr("Game state views"), "stateViews", "tools");
-	addGameAction(tr("View &palette..."), "paletteWindow", openControllerTView<PaletteView>(), "stateViews");
-	addGameAction(tr("View &sprites..."), "spriteWindow", openControllerTView<ObjView>(), "stateViews");
-	addGameAction(tr("View &tiles..."), "tileWindow", openControllerTView<TileView>(), "stateViews");
-	addGameAction(tr("View &map..."), "mapWindow", openControllerTView<MapView>(), "stateViews");
-	addGameAction(tr("&Frame inspector..."), "frameWindow", openNamedControllerTView<FrameView>(&m_frameView, false), "stateViews");
-	addGameAction(tr("View memory..."), "memoryView", openControllerTView<MemoryView>(), "stateViews");
-	addGameAction(tr("Search memory..."), "memorySearch", openControllerTView<MemorySearch>(), "stateViews");
-	addGameAction(tr("View &I/O registers..."), "ioViewer", openControllerTView<IOViewer>(), "stateViews");
+	addGameAction(tr("View &palette..."), "paletteWindow", PopupManager<PaletteView>(m_controller), "stateViews");
+	addGameAction(tr("View &sprites..."), "spriteWindow", PopupManager<ObjView>(m_controller), "stateViews");
+	addGameAction(tr("View &tiles..."), "tileWindow", PopupManager<TileView>(m_controller), "stateViews");
+	addGameAction(tr("View &map..."), "mapWindow", PopupManager<MapView>(m_controller), "stateViews");
+	addGameAction(tr("&Frame inspector..."), "frameWindow", m_frameView, "stateViews");
+	addGameAction(tr("View memory..."), "memoryView", PopupManager<MemoryView>(m_controller), "stateViews");
+	addGameAction(tr("Search memory..."), "memorySearch", PopupManager<MemorySearch>(m_controller), "stateViews");
+	addGameAction(tr("View &I/O registers..."), "ioViewer", PopupManager<IOViewer>(m_controller), "stateViews");
 
 #ifdef ENABLE_DEBUGGERS
-	addGameAction(tr("Log memory &accesses..."), "memoryAccessView", [this]() {
+	addGameAction(tr("Log memory &accesses..."), "memoryAccessView", PopupManager<MemoryAccessLogView>().constructWith([this]() {
 		std::weak_ptr<MemoryAccessLogController> controller = m_controller->memoryAccessLogController();
-		MemoryAccessLogView* view = new MemoryAccessLogView(controller);
-		connect(m_controller.get(), &CoreController::stopping, view, &QWidget::close);
-		openView(view);
-	}, "tools");
+		return new MemoryAccessLogView(controller);
+	}), "tools");
 #endif
 
 #if defined(USE_FFMPEG) && defined(M_CORE_GBA)
@@ -2012,6 +1919,18 @@ void Window::setupOptions() {
 		}
 	}, this);
 	m_config->updateOption("backgroundImage");
+}
+
+void Window::setupPopups() {
+	m_logView.constructWith(&m_log, this);
+	m_overrideView.constructWith(&m_controller, m_config, this);
+	// Is there a reason for SensorView to be keepalive?
+	m_sensorView.constructWith(&m_controller, &m_inputController, this).setKeepAlive(true);
+	m_dolphinView.constructWith(this).setKeepAlive(true);
+#ifdef USE_FFMPEG
+	m_videoView.constructWith(&m_controller).setKeepAlive(true);
+	m_gifView.constructWith(&m_controller).setKeepAlive(true);
+#endif
 }
 
 void Window::attachWidget(QWidget* widget) {

--- a/src/platform/qt/Window.h
+++ b/src/platform/qt/Window.h
@@ -20,13 +20,21 @@
 
 #include "ActionMapper.h"
 #include "CorePointerSource.h"
+#include "DolphinConnector.h"
+#include "FrameView.h"
+#include "GIFView.h"
 #include "InputController.h"
 #include "LoadSaveState.h"
 #include "LogController.h"
-#include "SettingsView.h"
+#include "LogView.h"
+#include "OverrideView.h"
+#include "PopupManager.h"
 #ifdef ENABLE_SCRIPTING
 #include "scripting/ScriptingController.h"
 #endif
+#include "SensorView.h"
+#include "SettingsView.h"
+#include "VideoView.h"
 
 namespace QGBA {
 
@@ -167,6 +175,7 @@ private:
 
 	void setupMenu(QMenuBar*);
 	void setupOptions();
+	void setupPopups();
 	void openStateWindow(LoadSave);
 
 	void attachWidget(QWidget* widget);
@@ -177,11 +186,6 @@ private:
 	void updateMRU();
 
 	void ensureScripting();
-
-	template <typename T, typename... A> std::function<void()> openTView(A... arg);
-	template <typename T, typename... A> std::function<void()> openControllerTView(A... arg);
-	template <typename T, typename... A> std::function<void()> openNamedTView(QPointer<T>*, bool keepalive, A... arg);
-	template <typename T, typename... A> std::function<void()> openNamedControllerTView(QPointer<T>*, bool keepalive, A... arg);
 
 	std::shared_ptr<Action> addGameAction(const QString& visibleName, const QString& name, Action::Function action, const QString& menu = {}, const QKeySequence& = {});
 	template<typename T, typename V> std::shared_ptr<Action> addGameAction(const QString& visibleName, const QString& name, T* obj, V (T::*action)(), const QString& menu = {}, const QKeySequence& = {});
@@ -210,7 +214,7 @@ private:
 	QMap<int, std::shared_ptr<Action>> m_frameSizes;
 
 	LogController m_log{0};
-	LogView* m_logView;
+	PopupManager<LogView> m_logView;
 #ifdef ENABLE_DEBUGGERS
 	DebuggerConsoleController* m_console = nullptr;
 #endif
@@ -244,14 +248,14 @@ private:
 	bool m_multiActive = true;
 	int m_playerId;
 
-	QPointer<OverrideView> m_overrideView;
-	QPointer<SensorView> m_sensorView;
-	QPointer<DolphinConnector> m_dolphinView;
-	QPointer<FrameView> m_frameView;
+	PopupManager<OverrideView> m_overrideView;
+	PopupManager<SensorView> m_sensorView;
+	PopupManager<DolphinConnector> m_dolphinView;
+	PopupManager<FrameView> m_frameView;
 
 #ifdef USE_FFMPEG
-	QPointer<VideoView> m_videoView;
-	QPointer<GIFView> m_gifView;
+	PopupManager<VideoView> m_videoView;
+	PopupManager<GIFView> m_gifView;
 #endif
 
 #ifdef ENABLE_GDB_STUB


### PR DESCRIPTION
This is the second of a series of patches that intend to refactor the way mGBA handles popup windows.

First PR: https://github.com/mgba-emu/mgba/pull/3549
Third PR: https://github.com/ahigerd/mgba/pull/4
Fourth PR: https://github.com/ahigerd/mgba/pull/5

## Description

`PopupManager` is a class that lazily constructs a QWidget subclass when it is requested to be shown. If the widget has already been constructed when the manager is triggered, it will be made visible, focused, and raised. If the widget is destroyed (including if it destroys itself) it will be reconstructed next time it is requested.

The `CorePointer` functionality from the previous PR is used if the QWidget subclass is a `CoreConsumer`. `CoreConsumer` subclasses will be attached to the `CorePointerSource` passed to the manager.

It uses a chainable API for configuration. This PR provides two configuration options:
* `setKeepAlive`: Disables the default behavior that configures popups to self-destruct when closed. 
* `constructWith`: Sets the argument list that the widget is constructed with. By default, if the widget has a constructor that accepts `CorePointerSource*` it will be used, otherwise the widget will be default-constructed if `constructWith` is not used. If the widget is not default-constructible, attempting to display the widget will fail with a warning. 

`PopupManager` is explicitly shared: if an instance of `PopupManager` is copied, the new instance will use the same data and manage the same popup instance. It is also a functor: calling a `PopupManager` instance using `operator()` will cause the popup to be displayed. Together, these two features allow a `PopupManager` to be instantiated inline as a callback, without needing to explicitly store the object in a member variable.

## Motivation

The motivation behind `PopupManager` is to encapsulate the behaviors that we want all popups in mGBA to obey. Popups currently have inconsistent behaviors and tend to need a fair amount of copy-pasted code to set up.

Before this PR, there were four different template functions for creating and opening popup windows -- one for normal construction, one for CoreController construction, one for "named" construction (to give `Window` a pointer to the popup instance), and one for "named" construction with CoreController. These functions accepted parameter lists for construction, which was a nice feature, but if none of the four suited your needs, you had to write extra boilerplate to work with the widget class. This meant that the other features like closing the popups when the core shut down would have to be reimplemented for each additional type of popup.

Furthermore, popups that were not "named" couldn't be controlled after they were opened. Most notably, this meant that you could have multiple copies of the same window open, and it required manual work to keep them in sync if that were to happen. If you had an existing window that was stacked into the background, the user couldn't use the menu item to get it back.

## Notes

In the interest of keeping concerns separated and keeping code review manageable, this PR only contains the minimal changes necessary to replace the use of the `open*TView` functions and a couple simple inline lambdas. (Plus `LogView`, which was extremely low-hanging fruit.) Any other popups that needed manual code before haven't been modified, so they will still have inconsistent behavior. Further PRs in the series will address these.